### PR TITLE
Add mixin capability

### DIFF
--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -42,10 +42,10 @@ class Bar extends $Bar {
   const Bar({this.foo, this.foos, this.driver, this.cache = null});
 }
 
-@FunctionalData()
-class Baz extends $Baz {
+@FunctionalData(type: FunctionalDataGeneratedType.asMixin)
+class Baz with $Baz {
   final math.Point prefixedField;
-  const Baz({this.prefixedField});
+  Baz({this.prefixedField});
 }
 
 main(List<String> arguments) {

--- a/example/bin/main.g.dart
+++ b/example/bin/main.g.dart
@@ -76,16 +76,16 @@ abstract class $Bar {
   bool operator ==(dynamic other) =>
       other.runtimeType == runtimeType &&
       foo == other.foo &&
-      const DeepCollectionEquality().equals(foos, other.foos) &&
+      DeepCollectionEquality().equals(foos, other.foos) &&
       driver == other.driver &&
-      const Ignore().equals(cache, other.cache);
+      Ignore().equals(cache, other.cache);
   @override
   int get hashCode {
     var result = 17;
     result = 37 * result + foo.hashCode;
-    result = 37 * result + const DeepCollectionEquality().hash(foos);
+    result = 37 * result + DeepCollectionEquality().hash(foos);
     result = 37 * result + driver.hashCode;
-    result = 37 * result + const Ignore().hash(cache);
+    result = 37 * result + Ignore().hash(cache);
     return result;
   }
 }
@@ -101,9 +101,8 @@ class Bar$ {
       (s_) => s_.cache, (s_, cache) => s_.copyWith(cache: cache));
 }
 
-abstract class $Baz {
+mixin $Baz {
   math.Point get prefixedField;
-  const $Baz();
   Baz copyWith({math.Point prefixedField}) =>
       Baz(prefixedField: prefixedField ?? this.prefixedField);
   String toString() => "Baz(prefixedField: $prefixedField)";

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,4 +10,9 @@ dependencies:
 dev_dependencies:
   build_runner:
   functional_data_generator:
+
+dependency_overrides:
+  functional_data_generator:
     path: ../functional_data_generator
+  functional_data:
+    path: ../functional_data

--- a/functional_data/lib/src/annotations.dart
+++ b/functional_data/lib/src/annotations.dart
@@ -1,7 +1,16 @@
 import 'package:collection/collection.dart';
 
+enum FunctionalDataGeneratedType {
+  asClass,
+  asMixin,
+}
+
 class FunctionalData {
-  const FunctionalData();
+  final FunctionalDataGeneratedType type;
+
+  const FunctionalData({
+    FunctionalDataGeneratedType type,
+  }) : type = type ?? FunctionalDataGeneratedType.asClass;
 }
 
 class CustomEquality {

--- a/functional_data_generator/lib/annotation_extensions.dart
+++ b/functional_data_generator/lib/annotation_extensions.dart
@@ -1,0 +1,34 @@
+import 'package:functional_data/functional_data.dart';
+import 'package:source_gen/source_gen.dart';
+
+extension FunctionalDataGeneratedTypeCoding on FunctionalDataGeneratedType {
+  static FunctionalDataGeneratedType fromConstantReader(
+    ConstantReader reader,
+  ) {
+    if (reader.isNull) {
+      return null;
+    }
+
+    final name = (f) => f.toString().split('.')[1];
+    final value = FunctionalDataGeneratedType.values.singleWhere(
+      (v) => reader.objectValue.getField(name(v)) != null,
+      orElse: () {
+        throw FallThroughError();
+      },
+    );
+
+    return value;
+  }
+}
+
+extension FunctionalDataCoding on FunctionalData {
+  static FunctionalData fromConstantReader(
+    ConstantReader reader,
+  ) {
+    return FunctionalData(
+      type: FunctionalDataGeneratedTypeCoding.fromConstantReader(
+        reader.read('type'),
+      ),
+    );
+  }
+}

--- a/functional_data_generator/pubspec.yaml
+++ b/functional_data_generator/pubspec.yaml
@@ -7,14 +7,18 @@ authors:
 homepage: https://github.com/spkersten/dart_functional_data
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.34.0 <0.39.0"
   build: ^1.1.0
   source_gen: ^0.9.2
   collection: ^1.14.11
-  functional_data: ">=0.2.0 <0.3.0"
+  functional_data:
 
 dev_dependencies:
   build_runner:
+
+dependency_overrides:
+  functional_data:
+    path: ../functional_data


### PR DESCRIPTION
The current implementation only works by inheriting from the
generated code. This change allows the annotation to be marked
as a mixin and then generates a mixin instead of an abstract class
with a constructor (hindering the ability to mixin.)

This will allow use to mixin the functional data code but extend from a class of our choosing instead of only being able to extend from the gen'd code.